### PR TITLE
Use libpng-config for compile and link options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
+CXX ?= g++
 LIBPNG_CONFIG ?= libpng-config
+LDFLAGS += $(shell $(LIBPNG_CONFIG) --cflags --ldflags)
 
 all: amosbank
 
 amosbank: amosbank.cc
-	g++ -o amosbank amosbank.cc `${LIBPNG_CONFIG} --cflags --ldflags`
+	$(CXX) -o amosbank amosbank.cc $(LDFLAGS)
 
 amosextract: amosextract.cc
-	g++ -o amosextract amosextract.cc
+	$(CXX) -o amosextract amosextract.cc
 
 clean:
 	rm -f amosbank amosextract

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
+LIBPNG_CONFIG ?= libpng-config
+
 all: amosbank
 
 amosbank: amosbank.cc
-	g++ -o amosbank amosbank.cc  -lpng -lz
+	g++ -o amosbank amosbank.cc `${LIBPNG_CONFIG} --cflags --ldflags`
 
 amosextract: amosextract.cc
 	g++ -o amosextract amosextract.cc
 
+clean:
+	rm -f amosbank amosextract

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ amosbank [![Build Status](https://travis-ci.org/dschwen/amosbank.svg)](https://t
 ========
 
 A converter/unpacker for AMOS banks (the Amiga programming language)   
-(c) by Daniel Schwen, 2012     
+(c) by Daniel Schwen, 2012-2017    
 Licensed under CC-BY-SA 3.0
 
 Usage:


### PR DESCRIPTION
@khval , would you mind checking if this works on Amiga OS? You won't even have to check out the branch. Just run the command line

```
g++ -o amosbank amosbank.cc `libpng-config --cflags --ldflags`
```

In the project directory.